### PR TITLE
Added support for `USER_MANAGED` publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ mavenCentral {
     // Token for Publisher API calls obtained from Sonatype official,
     // it should be Base64 encoded of "username:password".
     authToken = '<your token>'
+
+    // Whether the upload should be automatically published or not.
+    // Use `USER_MANAGED` if you wish to do this manually.
+    publishingType.set(PublishingType.AUTOMATIC)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ mavenCentral {
 
     // Whether the upload should be automatically published or not.
     // Use `USER_MANAGED` if you wish to do this manually.
-    publishingType.set(PublishingType.AUTOMATIC)
+    // Defaults to `AUTOMATIC`.
+    publishingType = PublishingType.AUTOMATIC
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ mavenCentral {
     // Whether the upload should be automatically published or not.
     // Use `USER_MANAGED` if you wish to do this manually.
     // This property is optional and defaults to `AUTOMATIC`.
-    publishingType = PublishingType.AUTOMATIC
+    publishingType = 'AUTOMATIC'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ mavenCentral {
 
     // Whether the upload should be automatically published or not.
     // Use `USER_MANAGED` if you wish to do this manually.
-    // Defaults to `AUTOMATIC`.
+    // This property is optional and defaults to `AUTOMATIC`.
     publishingType = PublishingType.AUTOMATIC
 }
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,7 +57,8 @@ mavenCentral {
     authToken = '<your token>'
     // 上传是否应该自动发布。
     // 如果您希望手动执行此操作，请使用 USER_MANAGED。
-    publishingType.set(PublishingType.AUTOMATIC)
+    // 默认为`AUTOMATIC`。
+    publishingType = PublishingType.AUTOMATIC
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -55,6 +55,9 @@ mavenCentral {
     repoDir = layout.buildDirectory.dir('repos/bundles')
     // 从 Sonatype 官方获取的 Publisher API 调用的 token，应为 Base64 编码后的 username:password
     authToken = '<your token>'
+    // 上传是否应该自动发布。
+    // 如果您希望手动执行此操作，请使用 USER_MANAGED。
+    publishingType.set(PublishingType.AUTOMATIC)
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,7 +58,7 @@ mavenCentral {
     // 上传是否应该自动发布。
     // 如果您希望手动执行此操作，请使用 USER_MANAGED。
     // 该属性是可选的，默认为“AUTOMATIC”。
-    publishingType = PublishingType.AUTOMATIC
+    publishingType = 'AUTOMATIC'
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,7 +57,7 @@ mavenCentral {
     authToken = '<your token>'
     // 上传是否应该自动发布。
     // 如果您希望手动执行此操作，请使用 USER_MANAGED。
-    // 默认为`AUTOMATIC`。
+    // 该属性是可选的，默认为“AUTOMATIC”。
     publishingType = PublishingType.AUTOMATIC
 }
 ```

--- a/maven-central-publish/build.gradle
+++ b/maven-central-publish/build.gradle
@@ -94,5 +94,5 @@ javadoc {
 mavenCentral {
     repoDir = layout.buildDirectory.dir('repos/bundles')
     authToken = System.getenv('MAVEN_UPLOAD_TOKEN')
-    publishingType = PublishingType.AUTOMATIC
+    publishingType = 'AUTOMATIC'
 }

--- a/maven-central-publish/build.gradle
+++ b/maven-central-publish/build.gradle
@@ -94,4 +94,5 @@ javadoc {
 mavenCentral {
     repoDir = layout.buildDirectory.dir('repos/bundles')
     authToken = System.getenv('MAVEN_UPLOAD_TOKEN')
+    publishingType = PublishingType.AUTOMATIC
 }

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/CentralPortalService.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/CentralPortalService.java
@@ -27,7 +27,7 @@ class CentralPortalService {
 
     private HttpClient httpClient = HttpClient.newHttpClient();
 
-    String uploadBundle(String url, PublishingType publishingType, String token, Path uploadFile) throws IOException, InterruptedException {
+    String uploadBundle(String url, String publishingType, String token, Path uploadFile) throws IOException, InterruptedException {
         String boundary = UUID.randomUUID().toString().replace("-", "");
         BodyPublisher filePartPublisher = getFilePartPublisher(boundary, uploadFile);
 

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/CentralPortalService.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/CentralPortalService.java
@@ -27,11 +27,11 @@ class CentralPortalService {
 
     private HttpClient httpClient = HttpClient.newHttpClient();
 
-    String uploadBundle(String url, String token, Path uploadFile) throws IOException, InterruptedException {
+    String uploadBundle(String url, PublishingType publishingType, String token, Path uploadFile) throws IOException, InterruptedException {
         String boundary = UUID.randomUUID().toString().replace("-", "");
         BodyPublisher filePartPublisher = getFilePartPublisher(boundary, uploadFile);
 
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url + publishingType))
                 .header("Authorization", "Bearer " + token)
                 .header("Content-Type", "multipart/form-data; boundary=" + boundary)
                 .POST(filePartPublisher)
@@ -79,5 +79,6 @@ class CentralPortalService {
         static final String PUBLISHING = "PUBLISHING";
         static final String PUBLISHED = "PUBLISHED";
         static final String PENDING = "PENDING";
+        static final String VALIDATED = "VALIDATED";
     }
 }

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/DefaultMavenCentralExtension.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/DefaultMavenCentralExtension.java
@@ -6,13 +6,15 @@ import org.gradle.api.provider.Property;
 
 class DefaultMavenCentralExtension implements MavenCentralExtension {
 
-    private static final String UPLOAD_URL = "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC";
+    private static final String UPLOAD_URL = "https://central.sonatype.com/api/v1/publisher/upload?publishingType=";
 
     private static final String STATUS_URL = "https://central.sonatype.com/api/v1/publisher/status?id=";
 
     private static final Integer MAX_WAIT = 60;
 
     private Property<String> uploadUrl;
+
+    private Property<PublishingType> publishingType;
 
     private Property<String> statusUrl;
 
@@ -27,6 +29,8 @@ class DefaultMavenCentralExtension implements MavenCentralExtension {
                 .convention(UPLOAD_URL);
         statusUrl = objectFactory.property(String.class)
                 .convention(STATUS_URL);
+        publishingType = objectFactory.property(PublishingType.class)
+                .convention(PublishingType.AUTOMATIC);
         authToken = objectFactory.property(String.class);
         repoDir = objectFactory.directoryProperty();
         maxWait = objectFactory.property(Integer.class)
@@ -37,6 +41,9 @@ class DefaultMavenCentralExtension implements MavenCentralExtension {
     public Property<String> getUploadUrl() {
         return uploadUrl;
     }
+
+    @Override
+    public Property<PublishingType> getPublishingType() { return publishingType; }
 
     @Override
     public Property<String> getStatusUrl() {

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/DefaultMavenCentralExtension.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/DefaultMavenCentralExtension.java
@@ -14,7 +14,7 @@ class DefaultMavenCentralExtension implements MavenCentralExtension {
 
     private Property<String> uploadUrl;
 
-    private Property<PublishingType> publishingType;
+    private Property<String> publishingType;
 
     private Property<String> statusUrl;
 
@@ -29,7 +29,7 @@ class DefaultMavenCentralExtension implements MavenCentralExtension {
                 .convention(UPLOAD_URL);
         statusUrl = objectFactory.property(String.class)
                 .convention(STATUS_URL);
-        publishingType = objectFactory.property(PublishingType.class)
+        publishingType = objectFactory.property(String.class)
                 .convention(PublishingType.AUTOMATIC);
         authToken = objectFactory.property(String.class);
         repoDir = objectFactory.directoryProperty();
@@ -43,7 +43,7 @@ class DefaultMavenCentralExtension implements MavenCentralExtension {
     }
 
     @Override
-    public Property<PublishingType> getPublishingType() { return publishingType; }
+    public Property<String> getPublishingType() { return publishingType; }
 
     @Override
     public Property<String> getStatusUrl() {

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/ExceptionFactory.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/ExceptionFactory.java
@@ -24,6 +24,8 @@ final class ExceptionFactory {
 
     static final String DEPLOYMENT_NOT_FINISHED = "Deployment hasn't finished, status is: [%s], please go to [%s] check your deployment.";
 
+    static final String PUBLISHING_TYPE_INVALID = "The publishingType is invalid. Accepted values are `AUTOMATIC` and `USER_MANAGED`.";
+
     static final String CHECKING_URL = "https://central.sonatype.com/publishing/deployments";
 
     private ExceptionFactory() {
@@ -56,5 +58,9 @@ final class ExceptionFactory {
 
     static GradleException deploymentNotFinished(String deploymentStatus) {
         return new GradleException(String.format(DEPLOYMENT_NOT_FINISHED, deploymentStatus, CHECKING_URL));
+    }
+
+    static GradleException publishingTypeInvalid() {
+        return new GradleException(PUBLISHING_TYPE_INVALID);
     }
 }

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/ExceptionFactory.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/ExceptionFactory.java
@@ -22,7 +22,7 @@ final class ExceptionFactory {
 
     static final String DEPLOYMENT_STATUS_IS_FIELD = "Deployment Status is failed: [%s], please go to [%s] check your deployment.";
 
-    static final String DEPLOYMENT_NOT_FINISHED = "Deployment haven't finished, status is: [%s], please go to [%s] check your deployment.";
+    static final String DEPLOYMENT_NOT_FINISHED = "Deployment hasn't finished, status is: [%s], please go to [%s] check your deployment.";
 
     static final String CHECKING_URL = "https://central.sonatype.com/publishing/deployments";
 

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/MavenCentralExtension.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/MavenCentralExtension.java
@@ -27,7 +27,7 @@ public interface MavenCentralExtension {
      *
      * @return Publishing type
      */
-    Property<PublishingType> getPublishingType();
+    Property<String> getPublishingType();
 
     /**
      * The URL for retrieving status of a deployment.

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/MavenCentralExtension.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/MavenCentralExtension.java
@@ -23,6 +23,13 @@ public interface MavenCentralExtension {
     Property<String> getUploadUrl();
 
     /**
+     * Whether to publish automatically or manually after a successful upload.
+     *
+     * @return Publishing type
+     */
+    Property<PublishingType> getPublishingType();
+
+    /**
      * The URL for retrieving status of a deployment.
      *
      * @return URL string
@@ -45,9 +52,11 @@ public interface MavenCentralExtension {
     DirectoryProperty getRepoDir();
 
     /**
-     * Max wait time for status API to get 'PUBLISHING' or 'PUBLISHED' status.
+     * Max wait time for status API to get 'PUBLISHING' or 'PUBLISHED' status when the
+     * publishing type is 'AUTOMATIC', or additionally 'VALIDATED' when the publishing type is
+     * 'USER_MANAGED'.
      *
-     * @return Duration in second
+     * @return Duration in seconds
      */
     Property<Integer> getMaxWait();
 }

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/PublishToCentralPortalTask.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/PublishToCentralPortalTask.java
@@ -78,7 +78,7 @@ public abstract class PublishToCentralPortalTask extends DefaultTask {
             throw uploadFileMustProvided();
         }
 
-        PublishingType currentPublishingType = publishingType.getOrElse(PublishingType.AUTOMATIC);
+        PublishingType currentPublishingType = publishingType.get();
         String deploymentId = centralPortalService.uploadBundle(uploadUrl.get(), currentPublishingType, authToken.get(), uploadFile.get().getAsFile().toPath());
 
         int count = 0;

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/PublishToCentralPortalTask.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/PublishToCentralPortalTask.java
@@ -92,25 +92,23 @@ public abstract class PublishToCentralPortalTask extends DefaultTask {
                 throw apiNotReturnDeploymentStateField();
             } else if (FAILED.equals(deploymentStatus)) {
                 throw deploymentStatusIsField(deploymentStatus);
+            } else if (isSuccessful(deploymentStatus)) {
+                getLogger().lifecycle("Upload file success! current status: {}.", deploymentStatus);
+                return;
             } else {
-                boolean isSuccessful = PUBLISHING.equals(deploymentStatus) || PUBLISHED.equals(deploymentStatus);
-
-                if (currentPublishingType == PublishingType.USER_MANAGED) {
-                    isSuccessful = isSuccessful || VALIDATED.equals(deploymentStatus);
-                }
-
-                if (isSuccessful) {
-                    getLogger().lifecycle("Upload file success! current status: {}.", deploymentStatus);
-                    return;
-                } else {
-                    ++count;
-                }
+                ++count;
             }
 
             if (count == checkCount) {
                 throw deploymentNotFinished(deploymentStatus);
             }
         }
+    }
+
+    private boolean isSuccessful(String deploymentStatus) {
+        return (publishingType.get() == PublishingType.USER_MANAGED && VALIDATED.equals(deploymentStatus))
+            || PUBLISHING.equals(deploymentStatus)
+            || PUBLISHED.equals(deploymentStatus);
     }
 
     /**

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/PublishingType.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/PublishingType.java
@@ -1,0 +1,19 @@
+package tech.yanand.gradle;
+
+/**
+ * Whether or not an upload should be published automatically or manually after successful validation.
+ */
+public enum PublishingType {
+    /**
+     * After an upload is successfully validated, the artifact will be published automatically.
+     * This is the default.
+     */
+    AUTOMATIC,
+
+    /**
+     * After an upload is successfully validated, the artifact will need to be
+     * published manually.
+     */
+    USER_MANAGED;
+}
+

--- a/maven-central-publish/src/main/java/tech/yanand/gradle/PublishingType.java
+++ b/maven-central-publish/src/main/java/tech/yanand/gradle/PublishingType.java
@@ -3,17 +3,20 @@ package tech.yanand.gradle;
 /**
  * Whether or not an upload should be published automatically or manually after successful validation.
  */
-public enum PublishingType {
+final class PublishingType {
+    private PublishingType() {
+        // Instantiation is not allowed
+    }
+
     /**
      * After an upload is successfully validated, the artifact will be published automatically.
      * This is the default.
      */
-    AUTOMATIC,
+    static final String AUTOMATIC = "AUTOMATIC";
 
     /**
      * After an upload is successfully validated, the artifact will need to be
      * published manually.
      */
-    USER_MANAGED;
+    static final String USER_MANAGED = "USER_MANAGED";
 }
-

--- a/maven-central-publish/src/test/java/tech/yanand/gradle/CentralPortalServiceTest.java
+++ b/maven-central-publish/src/test/java/tech/yanand/gradle/CentralPortalServiceTest.java
@@ -127,7 +127,7 @@ class CentralPortalServiceTest {
         int statusCode = 201;
         String body = "test body";
         Path uploadFile = Files.createTempFile(tempDir, "test_bundle", ".zip");
-        PublishingType publishingType = PublishingType.AUTOMATIC;
+        String publishingType = PublishingType.AUTOMATIC;
 
         when(response.statusCode()).thenReturn(statusCode);
         when(response.body()).thenReturn(body);
@@ -149,7 +149,7 @@ class CentralPortalServiceTest {
         int statusCode = 201;
         String body = "test body";
         Path uploadFile = Files.createTempFile(tempDir, "test_bundle", ".zip");
-        PublishingType publishingType = PublishingType.USER_MANAGED;
+        String publishingType = PublishingType.USER_MANAGED;
 
         when(response.statusCode()).thenReturn(statusCode);
         when(response.body()).thenReturn(body);

--- a/maven-central-publish/src/test/java/tech/yanand/gradle/CentralPortalServiceTest.java
+++ b/maven-central-publish/src/test/java/tech/yanand/gradle/CentralPortalServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.yanand.gradle.CentralPortalService.DeploymentStatus.PUBLISHING;
 import static tech.yanand.gradle.ExceptionFactory.CHECK_API_HTTP_STATUS_IS_NOT_OK;
@@ -67,7 +69,7 @@ class CentralPortalServiceTest {
 
         when(httpClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(response);
 
-        String actual = underTest.uploadBundle(UPLOAD_URL, TEST_TOKEN, uploadFile);
+        String actual = underTest.uploadBundle(UPLOAD_URL, PublishingType.AUTOMATIC, TEST_TOKEN, uploadFile);
 
         assertEquals(body, actual);
     }
@@ -84,7 +86,7 @@ class CentralPortalServiceTest {
         when(httpClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(response);
 
         GradleException actual = assertThrows(GradleException.class,
-                () -> underTest.uploadBundle(UPLOAD_URL, TEST_TOKEN, uploadFile));
+                () -> underTest.uploadBundle(UPLOAD_URL, PublishingType.AUTOMATIC, TEST_TOKEN, uploadFile));
 
         assertEquals(format(UPLOAD_API_HTTP_STATUS_IS_NOT_CREATED, statusCode, body), actual.getMessage());
     }
@@ -118,5 +120,49 @@ class CentralPortalServiceTest {
                 () -> underTest.getDeploymentStatus(STATUS_URL, TEST_TOKEN, DEPLOYMENT_ID));
 
         assertEquals(format(CHECK_API_HTTP_STATUS_IS_NOT_OK, statusCode, body), actual.getMessage());
+    }
+
+    @Test
+    void uploadBundle_automaticPublicationURI() throws IOException, InterruptedException {
+        int statusCode = 201;
+        String body = "test body";
+        Path uploadFile = Files.createTempFile(tempDir, "test_bundle", ".zip");
+        PublishingType publishingType = PublishingType.AUTOMATIC;
+
+        when(response.statusCode()).thenReturn(statusCode);
+        when(response.body()).thenReturn(body);
+        when(httpClient.send(any(), any(BodyHandler.class))).thenReturn(response);
+
+        underTest.uploadBundle(UPLOAD_URL, publishingType, TEST_TOKEN, uploadFile);
+
+        final ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(captor.capture(), any());
+
+        assertEquals(
+            captor.getValue().uri().toString(),
+            UPLOAD_URL + publishingType
+        );
+    }
+
+    @Test
+    void uploadBundle_userManagedPublicationURI() throws IOException, InterruptedException {
+        int statusCode = 201;
+        String body = "test body";
+        Path uploadFile = Files.createTempFile(tempDir, "test_bundle", ".zip");
+        PublishingType publishingType = PublishingType.USER_MANAGED;
+
+        when(response.statusCode()).thenReturn(statusCode);
+        when(response.body()).thenReturn(body);
+        when(httpClient.send(any(), any(BodyHandler.class))).thenReturn(response);
+
+        underTest.uploadBundle(UPLOAD_URL, publishingType, TEST_TOKEN, uploadFile);
+
+        final ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(captor.capture(), any());
+
+        assertEquals(
+            captor.getValue().uri().toString(),
+            UPLOAD_URL + publishingType
+        );
     }
 }

--- a/maven-central-publish/src/test/java/tech/yanand/gradle/PublishToCentralPortalTaskTest.java
+++ b/maven-central-publish/src/test/java/tech/yanand/gradle/PublishToCentralPortalTaskTest.java
@@ -5,7 +5,6 @@ import org.gradle.api.Project;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.internal.impldep.org.testng.internal.Nullable;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +32,7 @@ import static tech.yanand.gradle.ExceptionFactory.AUTH_TOKEN_NOT_PROVIDED;
 import static tech.yanand.gradle.ExceptionFactory.CHECKING_URL;
 import static tech.yanand.gradle.ExceptionFactory.DEPLOYMENT_NOT_FINISHED;
 import static tech.yanand.gradle.ExceptionFactory.DEPLOYMENT_STATUS_IS_FIELD;
+import static tech.yanand.gradle.ExceptionFactory.PUBLISHING_TYPE_INVALID;
 import static tech.yanand.gradle.ExceptionFactory.UPLOAD_FILE_MUST_PROVIDED;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +57,7 @@ class PublishToCentralPortalTaskTest {
     private Property<String> uploadUrl;
 
     @Mock
-    private Property<PublishingType> publishingType;
+    private Property<String> publishingType;
 
     @Mock
     private Property<String> statusUrl;
@@ -98,6 +98,17 @@ class PublishToCentralPortalTaskTest {
         GradleException actual = assertThrows(GradleException.class, underTest::executeTask);
 
         assertEquals(UPLOAD_FILE_MUST_PROVIDED, actual.getMessage());
+    }
+
+    @Test
+    void executeTask_publishingTypeIsInvalid() {
+        when(authToken.isPresent()).thenReturn(true);
+        when(uploadFile.isPresent()).thenReturn(true);
+        when(publishingType.get()).thenReturn("INVALID_VALUE");
+
+        GradleException actual = assertThrows(GradleException.class, underTest::executeTask);
+
+        assertEquals(PUBLISHING_TYPE_INVALID, actual.getMessage());
     }
 
     @Test
@@ -166,7 +177,7 @@ class PublishToCentralPortalTaskTest {
         stubbingTheInput(PublishingType.AUTOMATIC);
     }
 
-    private void stubbingTheInput(PublishingType currentPublishingType) throws IOException, InterruptedException {
+    private void stubbingTheInput(String currentPublishingType) throws IOException, InterruptedException {
         when(authToken.isPresent()).thenReturn(true);
         when(uploadFile.isPresent()).thenReturn(true);
         when(uploadUrl.get()).thenReturn(UPLOAD_URL);

--- a/maven-central-publish/src/test/java/tech/yanand/gradle/PublishToCentralPortalTaskTest.java
+++ b/maven-central-publish/src/test/java/tech/yanand/gradle/PublishToCentralPortalTaskTest.java
@@ -5,6 +5,7 @@ import org.gradle.api.Project;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.internal.impldep.org.testng.internal.Nullable;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 import static tech.yanand.gradle.CentralPortalService.DeploymentStatus.FAILED;
 import static tech.yanand.gradle.CentralPortalService.DeploymentStatus.PENDING;
 import static tech.yanand.gradle.CentralPortalService.DeploymentStatus.PUBLISHING;
+import static tech.yanand.gradle.CentralPortalService.DeploymentStatus.VALIDATED;
 import static tech.yanand.gradle.ExceptionFactory.API_NOT_RETURN_DEPLOYMENT_STATE_FIELD;
 import static tech.yanand.gradle.ExceptionFactory.AUTH_TOKEN_NOT_PROVIDED;
 import static tech.yanand.gradle.ExceptionFactory.CHECKING_URL;
@@ -53,6 +55,9 @@ class PublishToCentralPortalTaskTest {
 
     @Mock
     private Property<String> uploadUrl;
+
+    @Mock
+    private Property<PublishingType> publishingType;
 
     @Mock
     private Property<String> statusUrl;
@@ -137,16 +142,41 @@ class PublishToCentralPortalTaskTest {
         assertEquals(format(DEPLOYMENT_NOT_FINISHED, PENDING, CHECKING_URL), actual.getMessage());
     }
 
+    @Test
+    void executeTask_deploymentValidatingInUserAutomaticPublishing() throws IOException, InterruptedException {
+        stubbingTheInput();
+
+        when(centralPortalService.getDeploymentStatus(STATUS_URL, AUTH_TOKEN, DEPLOYMENT_ID)).thenReturn(VALIDATED);
+
+        GradleException actual = assertThrows(GradleException.class, underTest::executeTask);
+
+        assertEquals(format(DEPLOYMENT_NOT_FINISHED, VALIDATED, CHECKING_URL), actual.getMessage());
+    }
+
+    @Test
+    void executeTask_deploymentValidatingInUserManagedPublishing() throws IOException, InterruptedException {
+        stubbingTheInput(PublishingType.USER_MANAGED);
+
+        when(centralPortalService.getDeploymentStatus(STATUS_URL, AUTH_TOKEN, DEPLOYMENT_ID)).thenReturn(VALIDATED);
+
+        assertDoesNotThrow(underTest::executeTask);
+    }
+
     private void stubbingTheInput() throws IOException, InterruptedException {
+        stubbingTheInput(PublishingType.AUTOMATIC);
+    }
+
+    private void stubbingTheInput(PublishingType currentPublishingType) throws IOException, InterruptedException {
         when(authToken.isPresent()).thenReturn(true);
         when(uploadFile.isPresent()).thenReturn(true);
         when(uploadUrl.get()).thenReturn(UPLOAD_URL);
+        when(publishingType.getOrElse(PublishingType.AUTOMATIC)).thenReturn(currentPublishingType);
         when(statusUrl.get()).thenReturn(STATUS_URL);
         when(authToken.get()).thenReturn(AUTH_TOKEN);
         when(uploadFile.get()).thenReturn(regularFile);
         when(regularFile.getAsFile()).thenReturn(new File("bundle.zip"));
         when(maxWait.get()).thenReturn(10);
 
-        when(centralPortalService.uploadBundle(eq(UPLOAD_URL), eq(AUTH_TOKEN), any(Path.class))).thenReturn(DEPLOYMENT_ID);
+        when(centralPortalService.uploadBundle(eq(UPLOAD_URL), eq(currentPublishingType), eq(AUTH_TOKEN), any(Path.class))).thenReturn(DEPLOYMENT_ID);
     }
 }

--- a/maven-central-publish/src/test/java/tech/yanand/gradle/PublishToCentralPortalTaskTest.java
+++ b/maven-central-publish/src/test/java/tech/yanand/gradle/PublishToCentralPortalTaskTest.java
@@ -170,7 +170,7 @@ class PublishToCentralPortalTaskTest {
         when(authToken.isPresent()).thenReturn(true);
         when(uploadFile.isPresent()).thenReturn(true);
         when(uploadUrl.get()).thenReturn(UPLOAD_URL);
-        when(publishingType.getOrElse(PublishingType.AUTOMATIC)).thenReturn(currentPublishingType);
+        when(publishingType.get()).thenReturn(currentPublishingType);
         when(statusUrl.get()).thenReturn(STATUS_URL);
         when(authToken.get()).thenReturn(AUTH_TOKEN);
         when(uploadFile.get()).thenReturn(regularFile);


### PR DESCRIPTION
Hi @yananhub, thanks so much for your plugin. I hope you're okay with me opening a pull request, but I wanted to add support for `USER_MANAGED` publishing as currently your plugin only supports `AUTOMATIC`. 

I've tried to follow the same patterns you have used and haven't changed the default behaviour (it still defaults to `AUTOMATIC`). I have added tests and also tested this locally for my own project. 

What I have changed - 
- Added the `publishingType` property.
- Added the `VALIDATED` response status, which is treated as successful if the publishing type is `USER_MANAGED`.

Happy to take on feedback if there's anything you'd like changed. 

Thanks again.